### PR TITLE
Add LibDataBroker support

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,6 +1,9 @@
 package-as: OakLFGSorter
 manual-changelog: CHANGELOG.md
 
+tools-used:
+    - libdatabroker-1-1
+
 ignore:
   - dist
   - package-release.ps1

--- a/DataBroker.lua
+++ b/DataBroker.lua
@@ -1,0 +1,32 @@
+local _, addonTable = ...
+local ldbInst
+
+local function CreateLDB()
+    local LDBLib = LibStub and LibStub("LibDataBroker-1.1", true)
+    if not LDBLib then
+        return
+    end
+    if ldbInst then
+        return
+    end
+
+    ldbInst = LDBLib:NewDataObject("OakLFGSorter", {
+        type = "launcher",
+        text = "OakLFGSorter",
+        label = "OakLFGSorter",
+        icon = "Interface\\AddOns\\OakLFGSorter\\Media\\icon.png",
+        OnClick = addonTable.ClickMinimapButton,
+    })
+
+    function ldbInst:OnTooltipShow()
+        self:AddLine("Oakensoul LFG Sorter", 1, 1, 1)
+        self:AddLine("Left-click to open Oak's browser.", 1, 1, 1)
+        self:AddLine("Right-click to open Oak's options.", 1, 1, 1)
+    end
+end
+
+local eventFrame = CreateFrame("Frame")
+eventFrame:RegisterEvent("PLAYER_LOGIN")
+eventFrame:SetScript("OnEvent", function()
+    CreateLDB()
+end)

--- a/LibDataBroker-1.1.lua
+++ b/LibDataBroker-1.1.lua
@@ -1,0 +1,90 @@
+
+assert(LibStub, "LibDataBroker-1.1 requires LibStub")
+assert(LibStub:GetLibrary("CallbackHandler-1.0", true), "LibDataBroker-1.1 requires CallbackHandler-1.0")
+
+local lib, oldminor = LibStub:NewLibrary("LibDataBroker-1.1", 4)
+if not lib then return end
+oldminor = oldminor or 0
+
+
+lib.callbacks = lib.callbacks or LibStub:GetLibrary("CallbackHandler-1.0"):New(lib)
+lib.attributestorage, lib.namestorage, lib.proxystorage = lib.attributestorage or {}, lib.namestorage or {}, lib.proxystorage or {}
+local attributestorage, namestorage, callbacks = lib.attributestorage, lib.namestorage, lib.callbacks
+
+if oldminor < 2 then
+	lib.domt = {
+		__metatable = "access denied",
+		__index = function(self, key) return attributestorage[self] and attributestorage[self][key] end,
+	}
+end
+
+if oldminor < 3 then
+	lib.domt.__newindex = function(self, key, value)
+		if not attributestorage[self] then attributestorage[self] = {} end
+		if attributestorage[self][key] == value then return end
+		attributestorage[self][key] = value
+		local name = namestorage[self]
+		if not name then return end
+		callbacks:Fire("LibDataBroker_AttributeChanged", name, key, value, self)
+		callbacks:Fire("LibDataBroker_AttributeChanged_"..name, name, key, value, self)
+		callbacks:Fire("LibDataBroker_AttributeChanged_"..name.."_"..key, name, key, value, self)
+		callbacks:Fire("LibDataBroker_AttributeChanged__"..key, name, key, value, self)
+	end
+end
+
+if oldminor < 2 then
+	function lib:NewDataObject(name, dataobj)
+		if self.proxystorage[name] then return end
+
+		if dataobj then
+			assert(type(dataobj) == "table", "Invalid dataobj, must be nil or a table")
+			self.attributestorage[dataobj] = {}
+			for i,v in pairs(dataobj) do
+				self.attributestorage[dataobj][i] = v
+				dataobj[i] = nil
+			end
+		end
+		dataobj = setmetatable(dataobj or {}, self.domt)
+		self.proxystorage[name], self.namestorage[dataobj] = dataobj, name
+		self.callbacks:Fire("LibDataBroker_DataObjectCreated", name, dataobj)
+		return dataobj
+	end
+end
+
+if oldminor < 1 then
+	function lib:DataObjectIterator()
+		return pairs(self.proxystorage)
+	end
+
+	function lib:GetDataObjectByName(dataobjectname)
+		return self.proxystorage[dataobjectname]
+	end
+
+	function lib:GetNameByDataObject(dataobject)
+		return self.namestorage[dataobject]
+	end
+end
+
+if oldminor < 4 then
+	local next = pairs(attributestorage)
+	function lib:pairs(dataobject_or_name)
+		local t = type(dataobject_or_name)
+		assert(t == "string" or t == "table", "Usage: ldb:pairs('dataobjectname') or ldb:pairs(dataobject)")
+
+		local dataobj = self.proxystorage[dataobject_or_name] or dataobject_or_name
+		assert(attributestorage[dataobj], "Data object not found")
+
+		return next, attributestorage[dataobj], nil
+	end
+
+	local ipairs_iter = ipairs(attributestorage)
+	function lib:ipairs(dataobject_or_name)
+		local t = type(dataobject_or_name)
+		assert(t == "string" or t == "table", "Usage: ldb:ipairs('dataobjectname') or ldb:ipairs(dataobject)")
+
+		local dataobj = self.proxystorage[dataobject_or_name] or dataobject_or_name
+		assert(attributestorage[dataobj], "Data object not found")
+
+		return ipairs_iter, attributestorage[dataobj], 0
+	end
+end

--- a/LibStub.lua
+++ b/LibStub.lua
@@ -1,0 +1,30 @@
+-- LibStub is a simple versioning stub meant for use in Libraries.  http://www.wowace.com/wiki/LibStub for more info
+-- LibStub is hereby placed in the Public Domain Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel, joshborke
+local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
+local LibStub = _G[LIBSTUB_MAJOR]
+
+if not LibStub or LibStub.minor < LIBSTUB_MINOR then
+	LibStub = LibStub or {libs = {}, minors = {} }
+	_G[LIBSTUB_MAJOR] = LibStub
+	LibStub.minor = LIBSTUB_MINOR
+
+	function LibStub:NewLibrary(major, minor)
+		assert(type(major) == "string", "Bad argument #2 to `NewLibrary' (string expected)")
+		minor = assert(tonumber(string.match(minor, "%d+")), "Minor version must either be a number or contain a number.")
+
+		local oldminor = self.minors[major]
+		if oldminor and oldminor >= minor then return nil end
+		self.minors[major], self.libs[major] = minor, self.libs[major] or {}
+		return self.libs[major], oldminor
+	end
+
+	function LibStub:GetLibrary(major, silent)
+		if not self.libs[major] and not silent then
+			error(("Cannot find a library instance of %q."):format(tostring(major)), 2)
+		end
+		return self.libs[major], self.minors[major]
+	end
+
+	function LibStub:IterateLibraries() return pairs(self.libs) end
+	setmetatable(LibStub, { __call = LibStub.GetLibrary })
+end

--- a/MinimapButton.lua
+++ b/MinimapButton.lua
@@ -149,6 +149,22 @@ local function OpenOakOptions()
 end
 addonTable.OpenOakOptions = OpenOakOptions
 
+addonTable.ClickMinimapButton = function(_, mouseButton)
+    if mouseButton == "RightButton" then
+        OpenOakOptions()
+    else
+        if addonTable.OAK_LFG and addonTable.OAK_LFG:IsShown() then
+            addonTable.userExplicitlyClosed = true
+            if addonTable.OAK_SEARCH and addonTable.OAK_SEARCH:IsShown() then
+                addonTable.OAK_SEARCH:Hide()
+            end
+            addonTable.OAK_LFG:Hide()
+        else
+            OpenOakBrowser()
+        end
+    end
+end
+
 function addonTable.UpdateMinimapButtonVisibility()
     if not minimapButton then
         return
@@ -213,21 +229,7 @@ local function CreateMinimapButton()
     highlight:SetSize(52, 52)
     highlight:SetPoint("CENTER", button, "CENTER", 0, 1)
 
-    button:SetScript("OnClick", function(_, mouseButton)
-        if mouseButton == "RightButton" then
-            OpenOakOptions()
-        else
-            if addonTable.OAK_LFG and addonTable.OAK_LFG:IsShown() then
-                addonTable.userExplicitlyClosed = true
-                if addonTable.OAK_SEARCH and addonTable.OAK_SEARCH:IsShown() then
-                    addonTable.OAK_SEARCH:Hide()
-                end
-                addonTable.OAK_LFG:Hide()
-            else
-                OpenOakBrowser()
-            end
-        end
-    end)
+    button:SetScript("OnClick", addonTable.ClickMinimapButton)
 
     button:SetScript("OnDragStart", function(self)
         self:SetScript("OnUpdate", UpdateDragPosition)

--- a/OakLFGSorter.toc
+++ b/OakLFGSorter.toc
@@ -29,3 +29,5 @@ MythicPlus_Panel.lua
 MinimapButton.lua
 Search_Signup.lua
 Search_Integration.lua
+LibStub.lua
+DataBroker.lua


### PR DESCRIPTION
This adds a button on a DataBroker addon, such as Bazooka, for opening Oak LFG Sorter to allow the minimap to stay clean if desired.

<img width="1449" height="404" alt="image" src="https://github.com/user-attachments/assets/8a3afcea-bc86-46c7-bf46-f83e3e7096eb" />
